### PR TITLE
[feat] 최적화 프롬프트 생성 + 응답 받기 

### DIFF
--- a/src/main/java/jpabasic/truthaiserver/common/prompt/PromptRegistry.java
+++ b/src/main/java/jpabasic/truthaiserver/common/prompt/PromptRegistry.java
@@ -23,7 +23,7 @@ public class PromptRegistry {
     public PromptTemplate getByKey(String key) {
         PromptTemplate template = byKey.get(key);
         if(template == null) {
-            throw new BusinessException(ErrorMessages.PROMPT_NULL_ERROR);
+            throw new BusinessException(ErrorMessages.PROMPT_TEMPLATE_NOT_FOUND);
         }
         return template;
     }

--- a/src/main/java/jpabasic/truthaiserver/config/AiConfig.java
+++ b/src/main/java/jpabasic/truthaiserver/config/AiConfig.java
@@ -28,6 +28,12 @@ public class AiConfig {
     @Value("${gemini.api.url}")
     private String geminiApiUrl;
 
+    @Value("${perplexity.api.url}")
+    private String perplexityApiUrl;
+
+    @Value("${perplexity.api.key}")
+    private String perplexityApiKey;
+
     private final WebClient.Builder webClientBuilder;
 
     public AiConfig(WebClient.Builder webClientBuilder) {
@@ -58,6 +64,14 @@ public class AiConfig {
     public WebClient geminiClient(){
         return webClientBuilder
                 .baseUrl(geminiApiUrl)
+                .build();
+    }
+
+    @Bean
+    public WebClient perplexityClient(){
+        return webClientBuilder
+                .baseUrl(perplexityApiUrl)
+                .defaultHeader("Authorization","Bearer "+perplexityApiKey)
                 .build();
     }
 

--- a/src/main/java/jpabasic/truthaiserver/controller/PromptController.java
+++ b/src/main/java/jpabasic/truthaiserver/controller/PromptController.java
@@ -6,6 +6,7 @@ import jpabasic.truthaiserver.domain.User;
 import jpabasic.truthaiserver.dto.answer.LlmRequestDto;
 import jpabasic.truthaiserver.dto.prompt.PromptAnswerDto;
 import jpabasic.truthaiserver.service.LlmService;
+import jpabasic.truthaiserver.service.SourcesService;
 import jpabasic.truthaiserver.service.prompt.PromptService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -22,18 +23,20 @@ public class PromptController {
 
     private final PromptService promptService;
     private final LlmService llmService;
+    private final SourcesService sourcesService;
 
-    public PromptController(PromptService promptService,LlmService llmService)
+    public PromptController(PromptService promptService,LlmService llmService,SourcesService sourcesService)
     {
         this.promptService = promptService;
         this.llmService = llmService;
+        this.sourcesService = sourcesService;
     }
 
     @PostMapping("/create-best")
     @Operation(summary="최적화 프롬프트 생성")
     public ResponseEntity<Map<String,Object>> savePrompt(@RequestBody LlmRequestDto dto,@AuthenticationPrincipal User user){
         Long promptId=promptService.saveOriginalPrompt(dto,user);
-        String optimizedPrompt=promptService.getOptimizedPrompt(dto,user);
+        String optimizedPrompt=promptService.getOptimizedPrompt(dto,promptId);
 
         Map<String,Object> map=new HashMap<>();
         map.put("optimizedPrompt",optimizedPrompt);
@@ -56,6 +59,7 @@ public class PromptController {
                                                               @AuthenticationPrincipal User user){
         String optimizedPrompt=promptService.optimizingPrompt(dto,user,promptId);
         PromptAnswerDto result=llmService.seperateAnswers(promptId,optimizedPrompt);
+//        sourcesService.saveSources(result); //출처 저장은 ai 교차 검증 시에 하는걸로..
         return ResponseEntity.ok(result);
     }
 

--- a/src/main/java/jpabasic/truthaiserver/controller/PromptController.java
+++ b/src/main/java/jpabasic/truthaiserver/controller/PromptController.java
@@ -2,11 +2,17 @@ package jpabasic.truthaiserver.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jpabasic.truthaiserver.domain.User;
 import jpabasic.truthaiserver.dto.answer.LlmRequestDto;
+import jpabasic.truthaiserver.dto.prompt.PromptAnswerDto;
+import jpabasic.truthaiserver.service.LlmService;
 import jpabasic.truthaiserver.service.prompt.PromptService;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.annotation.CurrentSecurityContext;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.HashMap;
 import java.util.Map;
 
 @RestController
@@ -15,25 +21,42 @@ import java.util.Map;
 public class PromptController {
 
     private final PromptService promptService;
+    private final LlmService llmService;
 
-    public PromptController(PromptService promptService) {
+    public PromptController(PromptService promptService,LlmService llmService)
+    {
         this.promptService = promptService;
+        this.llmService = llmService;
     }
 
     @PostMapping("/create-best")
     @Operation(summary="최적화 프롬프트 생성")
-    public ResponseEntity<String> savePrompt(@RequestBody LlmRequestDto dto){
+    public ResponseEntity<Map<String,Object>> savePrompt(@RequestBody LlmRequestDto dto,@AuthenticationPrincipal User user){
+        Long promptId=promptService.saveOriginalPrompt(dto,user);
+        String optimizedPrompt=promptService.getOptimizedPrompt(dto,user);
 
-        String optimizedPrompt=promptService.getOptimizedPrompt(dto);
-        return ResponseEntity.ok(optimizedPrompt);
+        Map<String,Object> map=new HashMap<>();
+        map.put("optimizedPrompt",optimizedPrompt);
+        map.put("promptId",promptId);
+        return ResponseEntity.ok(map); //저장된 promptId도 함께 반환.
     }
 
-    @PostMapping("/get-best")
-    @Operation(summary="최적화 프롬프트를 통해 응답 생성 받기")
-    public ResponseEntity<String> getOptimizedAnswer(@RequestBody LlmRequestDto dto){
+//    @PostMapping("/get-best")
+//    @Operation(summary="최적화 프롬프트를 통해 응답 생성 받기")
+//    public ResponseEntity<String> getOptimizedAnswer(@RequestBody LlmRequestDto dto, @AuthenticationPrincipal User user){
+//
+//        String optimizedPrompt=promptService.optimizingPrompt(dto);
+//        return ResponseEntity.ok(optimizedPrompt);
+//    }
 
-        String optimizedPrompt=promptService.optimizingPrompt(dto);
-        return ResponseEntity.ok(optimizedPrompt);
+    @PostMapping("/get-best/organized")
+    @Operation(summary="최적화 프롬프트를 통해 응답 생성 받기")
+    public ResponseEntity<PromptAnswerDto> getOrganizedAnswer(@RequestParam Long promptId,
+                                                              @RequestBody LlmRequestDto dto,
+                                                              @AuthenticationPrincipal User user){
+        String optimizedPrompt=promptService.optimizingPrompt(dto,user,promptId);
+        PromptAnswerDto result=llmService.seperateAnswers(promptId,optimizedPrompt);
+        return ResponseEntity.ok(result);
     }
 
     @PostMapping("/summarize")

--- a/src/main/java/jpabasic/truthaiserver/controller/PromptController.java
+++ b/src/main/java/jpabasic/truthaiserver/controller/PromptController.java
@@ -20,13 +20,21 @@ public class PromptController {
         this.promptService = promptService;
     }
 
-//    @PostMapping("/create-best")
-//    @Operation(summary="최적화 프롬프트 생성하기")
-//    public ResponseEntity<String> savePrompt(@RequestBody String originalPrompt, @RequestParam Long userId){
-//
-//        String optimizedPrompt=promptService.optimizingPrompt(originalPrompt,userId);
-//        return ResponseEntity.ok(optimizedPrompt);
-//    }
+    @PostMapping("/create-best")
+    @Operation(summary="최적화 프롬프트 생성")
+    public ResponseEntity<String> savePrompt(@RequestBody LlmRequestDto dto){
+
+        String optimizedPrompt=promptService.getOptimizedPrompt(dto);
+        return ResponseEntity.ok(optimizedPrompt);
+    }
+
+    @PostMapping("/get-best")
+    @Operation(summary="최적화 프롬프트를 통해 응답 생성 받기")
+    public ResponseEntity<String> getOptimizedAnswer(@RequestBody LlmRequestDto dto){
+
+        String optimizedPrompt=promptService.optimizingPrompt(dto);
+        return ResponseEntity.ok(optimizedPrompt);
+    }
 
     @PostMapping("/summarize")
     @Operation(summary="프롬프트 내용 요약하기",description="model 필드 값은 gpt로 주세요!")

--- a/src/main/java/jpabasic/truthaiserver/controller/SourceController.java
+++ b/src/main/java/jpabasic/truthaiserver/controller/SourceController.java
@@ -1,0 +1,23 @@
+package jpabasic.truthaiserver.controller;
+
+import jpabasic.truthaiserver.service.SourcesService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+
+@Controller
+public class SourceController {
+
+    private final SourcesService sourcesService;
+
+    public SourceController(SourcesService sourcesService) {
+        this.sourcesService = sourcesService;
+    }
+
+
+//    @GetMapping("/test")
+//    public ResponseEntity<?> seperateTest(){
+//        sourcesService.separateUrl();
+//        return ResponseEntity.ok().build();
+//    }
+}

--- a/src/main/java/jpabasic/truthaiserver/domain/Answer.java
+++ b/src/main/java/jpabasic/truthaiserver/domain/Answer.java
@@ -36,7 +36,7 @@ public class Answer extends BaseEntity{
     private Prompt prompt;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "user_id")
+    @JoinColumn(name = "user_id",nullable=false)
     private User user;
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/jpabasic/truthaiserver/domain/Answer.java
+++ b/src/main/java/jpabasic/truthaiserver/domain/Answer.java
@@ -55,4 +55,11 @@ public class Answer extends BaseEntity{
         this.model = model;
         this.content = answer;
     }
+
+    public Answer(String content,LLMModel model,Prompt prompt,User user){
+        this.content = content;
+        this.model = model;
+        this.prompt = prompt;
+        this.user = user;
+    }
 }

--- a/src/main/java/jpabasic/truthaiserver/domain/Prompt.java
+++ b/src/main/java/jpabasic/truthaiserver/domain/Prompt.java
@@ -41,4 +41,14 @@ public class Prompt extends BaseEntity{
         this.answers = answers;
         this.user = user;
     }
+
+    public void optimize(String optimizedPrompt) {
+        this.optimizedPrompt = optimizedPrompt;
+    }
+
+    public void addAnswer(Answer answer) {
+        answers.add(answer);
+    }
+
+
 }

--- a/src/main/java/jpabasic/truthaiserver/domain/PromptDomain.java
+++ b/src/main/java/jpabasic/truthaiserver/domain/PromptDomain.java
@@ -1,0 +1,42 @@
+package jpabasic.truthaiserver.domain;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@JsonFormat(shape = JsonFormat.Shape.OBJECT)
+public enum PromptDomain {
+    POLITICS("정치"),
+    ECONOMICS("경제"),
+    SOCIAL("사회"),
+    CULTURE("문화"),
+    SCIENCE("IT,과학"),
+    INTERNATIONAL("국제"),
+    CLIMATE("재난,기후,환경"),
+    LIFE("생활,건강"),
+    SPORTS("스포츠"),
+    ENTERTAINMENT("연예"),
+    WEATHER("날씨"),
+    ELSE("기타");
+
+    final private String name;
+
+    private static final Map<String,PromptDomain> KOREAN_TO_ENUM=new HashMap<>();
+    private PromptDomain(String name) {
+        this.name = name;
+    }
+
+    public String getName() {
+        return this.name;
+    }
+
+    public static PromptDomain nameOf(String name) {
+        for(PromptDomain domain : PromptDomain.values()) {
+            if(domain.name().equals(name)) {
+                return domain;
+            }
+        }
+        return null;
+    }
+}

--- a/src/main/java/jpabasic/truthaiserver/domain/Source.java
+++ b/src/main/java/jpabasic/truthaiserver/domain/Source.java
@@ -24,4 +24,17 @@ public class Source {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "claim_id")
     private Claim claim;
+
+    //prompt or answer와 매핑
+    @ManyToOne(fetch=FetchType.LAZY)
+    @JoinColumn(name="answer_id")
+    private Answer answer;
+
+    public Source(String sourceTitle,String sourceUrl,Answer answer) {
+        this.sourceTitle = sourceTitle;
+        this.sourceUrl = sourceUrl;
+        this.answer = answer;
+    }
+
+
 }

--- a/src/main/java/jpabasic/truthaiserver/dto/answer/LlmRequestDto.java
+++ b/src/main/java/jpabasic/truthaiserver/dto/answer/LlmRequestDto.java
@@ -3,6 +3,7 @@ package jpabasic.truthaiserver.dto.answer;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jpabasic.truthaiserver.domain.LLMModel;
+import jpabasic.truthaiserver.domain.PromptDomain;
 import jpabasic.truthaiserver.exception.BusinessException;
 import jpabasic.truthaiserver.exception.ErrorMessages;
 import lombok.*;
@@ -28,7 +29,7 @@ public class LlmRequestDto {
     private String persona;
 
     @Schema(description="도메인 : 유저가 물어보려는 내용의 분야",required=false)
-    private String domain;
+    private PromptDomain promptDomain;
 
     public List<LLMModel> toModelEnums(){
         return models.stream()
@@ -41,5 +42,6 @@ public class LlmRequestDto {
                 })
                 .collect(Collectors.toList());
     }
+
 
 }

--- a/src/main/java/jpabasic/truthaiserver/dto/answer/LlmRequestDto.java
+++ b/src/main/java/jpabasic/truthaiserver/dto/answer/LlmRequestDto.java
@@ -24,6 +24,12 @@ public class LlmRequestDto {
     @NotBlank(message="프롬프트를 작성해주세요.")
     private String question;
 
+    @Schema(description="페르소나:최적화 생성 시에만 입력 필수",required=false)
+    private String persona;
+
+    @Schema(description="도메인 : 유저가 물어보려는 내용의 분야",required=false)
+    private String domain;
+
     public List<LLMModel> toModelEnums(){
         return models.stream()
                 .map(model->{

--- a/src/main/java/jpabasic/truthaiserver/dto/prompt/BasePromptTemplate.java
+++ b/src/main/java/jpabasic/truthaiserver/dto/prompt/BasePromptTemplate.java
@@ -1,5 +1,6 @@
 package jpabasic.truthaiserver.dto.prompt;
 
+import jpabasic.truthaiserver.domain.PromptDomain;
 import jpabasic.truthaiserver.dto.answer.Message;
 
 import java.util.ArrayList;
@@ -9,12 +10,11 @@ import java.util.Map;
 
 public abstract class BasePromptTemplate implements PromptTemplate {
 
-    @Override 
-    //프롬프트 최적화 
-    public List<Message> render(Message message, String persona,String domain) {
+    @Override
+    public List<Message> render(Message message, String persona, PromptDomain domain) {
         List<Message> msgs = new ArrayList<>();
-        
-        msgs.add(new Message("system", systemIdentity(domain,persona)));    
+
+        msgs.add(new Message("system", systemIdentity(domain, persona)));
         return executeInternalRender(message, msgs);
     }
 
@@ -22,12 +22,12 @@ public abstract class BasePromptTemplate implements PromptTemplate {
     // 내용 요약
     public List<Message> render(Message message) {
         List<Message> msgs = new ArrayList<>();
-        return executeInternalRender(message,msgs);
+        return executeInternalRender(message, msgs);
     }
 
 
     private List<Message> executeInternalRender(Message message, List<Message> msgs) {
-        Map<String, Object> vars=new HashMap<>();
+        Map<String, Object> vars = new HashMap<>();
 
         msgs.add(new Message("system", globalGuidelines()));     // 전역 가드레일
         String domain = domainGuidelines();
@@ -44,22 +44,72 @@ public abstract class BasePromptTemplate implements PromptTemplate {
     }
 
     // === 아래 훅(Hook) 메서드들만 서브클래스에서 바꿔 끼움 ===
-    protected abstract String systemIdentity(String domain,String persona);
+    protected abstract String systemIdentity(PromptDomain domain, String persona);
 
     protected String globalGuidelines() {
         return
                 """
-                Take a deep breath and let's work this out.\s
-                Be sure we have the right answer.
-                """;
+                                ⭐ You are a fact-verification-based answering system.
+                                ⭐ Never generate any information unless the source is 100% clearly verified.
+                                ⭐ Do not provide guesses, hypothetical scenarios, analogies, or examples.
+                                ⭐ If no source is available, you must respond with "No source available" only.
+                        """;
     }
 
     // 도메인별 추가 규칙 (없으면 빈 문자열 반환)
-    protected abstract String domainGuidelines();
+    protected String domainGuidelines() {
+        return "";
+    }
 
 
     // Few-shot 예시(필요 시)
-    protected String fewShotExamples(Map<String, Object> vars) { return ""; }
+    protected String fewShotExamples(Map<String, Object> vars) {
+        return
+                """
+                        Always follow these forms.
+                        🚨 But remember if there's no sources, just say there's no sources.
+                        🚨 Do not ever guess yourself.
+                     
+                        
+                        ## Answer
+                                - give the conclusion of question, and tell the simple reason/context.
+                                - Mark controversial/uncertain parts.
+                        ## Why
+                                - Suggest a core reason of your answer in one sentence.
+                        ## Sources
+                                - suggest more than 2 trustful sources with url.(official report,thesis,newspaper,legacy media)
+                                - (ex.)
+                                    - source 1: url
+                                    - source 2: url
+                        
+                        these are few examples.
+                                ## Answer
+                                    비타민 C가 감기를 완전히 예방한다는 주장은 과장입니다. 일부 연구에서 증상 기간 단축이나 경미한 완화가 보고되었지만,
+                                    일관된 예방 효과는 확인되지 않았습니다. 감기 예방에는 손 위생, 충분한 수면, 예방접종(인플루엔자) 등 종합적 관리가 중요합니다.
+                        
+                                    ## Why
+                                    무작위대조시험 종합 결과가 예방 효과의 일관성을 뒷받침하지 않습니다.
+                        
+                                    ## Sources
+                                    - Source 1: Hemilä H, Chalker E. Cochrane Review (2013, updated).\s
+                                    - Source 2: CDC. Common Cold: Prevention & Treatment.
+                        
+                                ---------------------------
+                        
+                                 ## Answer
+                                    블록체인 거래가 모두 완전한 익명이라는 주장은 부정확합니다. 비트코인은 가명성(pseudonymity)에 가깝고,
+                                    온체인 분석과 규제 보고의 결합으로 특정 지갑이 실사용자와 연결되는 사례가 많습니다. 프라이버시 코인도 한계가 존재합니다.
+                        
+                                 ## Why
+                                    주소-거래 그래프 분석과 규제 데이터 결합으로 가명성이 실명화될 수 있습니다.
+                        
+                                 ## Sources
+                                     - Source 1: Chainalysis Industry Reports.
+                                     - Source 2: Narayanan et al., "Bitcoin and Cryptocurrency Technologies" (Princeton).
+                        
+                        """;
+
+    }
 
 
     // 사용자 입력을 최종적으로 문자열로 구성

--- a/src/main/java/jpabasic/truthaiserver/dto/prompt/PromptAnswerDto.java
+++ b/src/main/java/jpabasic/truthaiserver/dto/prompt/PromptAnswerDto.java
@@ -1,0 +1,56 @@
+package jpabasic.truthaiserver.dto.prompt;
+
+import jpabasic.truthaiserver.dto.answer.Message;
+import lombok.AllArgsConstructor;
+import org.apache.commons.codec.language.bm.Rule;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+//프롬프트 최종 렌더 결과
+public record PromptAnswerDto(Long promptId,String answer, List<Map<String,String>> sources) {
+
+    public PromptAnswerDto(Long promptId,String response){
+        this(
+                promptId,
+                parseAnswer(response),
+                parseSources(response)
+        );
+    }
+
+    private static String parseAnswer(String response){
+        //##답변 이후 부터 ##Sources 전까지 추출
+        String[] parts=response.split("##Sources",2);
+        if(parts.length>0){
+            return parts[0]
+                    .replace("##답변","")
+                    .trim();
+        }
+        return "";
+    }
+
+    private static List<Map<String,String>> parseSources(String response){
+        List<Map<String,String>> sources=new ArrayList<>();
+
+        //마크다운 링크 패턴 : [링크텍스트] (URL)
+        /**
+         * - Harvard T.H. Chan School of Public Health. "The Nutrition Source - Carbohydrates." [www.hsph.harvard.edu](https://www.hsph.harvard.edu/nutritionsource/carbohydrates/)
+         */
+        Pattern pattern= Pattern.compile("-\\s*(.*?)\\s*\\[(.*?)\\]\\((.*?)\\)");
+        Matcher matcher=pattern.matcher(response);
+
+        while(matcher.find()){
+            Map<String,String> map=new HashMap<>();
+            map.put("title",matcher.group(1).trim()); //설명/출처명
+            map.put("displayText",matcher.group(2).trim()); //링크 표시 텍스트
+            map.put("url",matcher.group(3).trim()); //실제 URL
+            sources.add(map);
+        }
+        System.out.println(sources);
+        return sources;
+    }
+}

--- a/src/main/java/jpabasic/truthaiserver/dto/prompt/PromptRenderResult.java
+++ b/src/main/java/jpabasic/truthaiserver/dto/prompt/PromptRenderResult.java
@@ -1,9 +1,0 @@
-package jpabasic.truthaiserver.dto.prompt;
-
-import jpabasic.truthaiserver.dto.answer.Message;
-
-import java.util.List;
-
-//프롬프트 최종 렌더 결과
-public record PromptRenderResult(List<Message> messages, String templateKey) {
-}

--- a/src/main/java/jpabasic/truthaiserver/dto/prompt/PromptTemplate.java
+++ b/src/main/java/jpabasic/truthaiserver/dto/prompt/PromptTemplate.java
@@ -1,5 +1,6 @@
 package jpabasic.truthaiserver.dto.prompt;
 
+import jpabasic.truthaiserver.domain.PromptDomain;
 import jpabasic.truthaiserver.dto.answer.Message;
 
 import java.util.List;
@@ -11,7 +12,10 @@ public interface PromptTemplate {
     //동적 변수(맵) 받아서 messages 구성
 //    PromptRenderResult render(Map<String,Object> vars);
 
-    List<Message> render(Message message, String persona,String domain);
+    List<Message> render(Message message, String persona, PromptDomain domain);
+
+//    //프롬프트 최적화
+//    List<Message> render(Message message, String persona, PromptDomain domain);
 
     List<Message> render(Message message);
 }

--- a/src/main/java/jpabasic/truthaiserver/dto/prompt/PromptTemplate.java
+++ b/src/main/java/jpabasic/truthaiserver/dto/prompt/PromptTemplate.java
@@ -11,5 +11,7 @@ public interface PromptTemplate {
     //동적 변수(맵) 받아서 messages 구성
 //    PromptRenderResult render(Map<String,Object> vars);
 
+    List<Message> render(Message message, String persona,String domain);
+
     List<Message> render(Message message);
 }

--- a/src/main/java/jpabasic/truthaiserver/exception/ErrorMessages.java
+++ b/src/main/java/jpabasic/truthaiserver/exception/ErrorMessages.java
@@ -15,6 +15,8 @@ public class ErrorMessages {
     //prompt 관련
     public static final String PROMPT_GENERATE_ERROR="프롬프트 저장에 문제가 생겼어요.";
     public static final String PROMPT_TEMPLATE_NOT_FOUND="해당 프롬프트는 저장소에 있지 않아요.";
+    public static final String PROMPT_NOT_FOUND="해당 질문을 찾을 수 없어요.";
+
 
 
 

--- a/src/main/java/jpabasic/truthaiserver/exception/ErrorMessages.java
+++ b/src/main/java/jpabasic/truthaiserver/exception/ErrorMessages.java
@@ -14,7 +14,8 @@ public class ErrorMessages {
 
     //prompt 관련
     public static final String PROMPT_GENERATE_ERROR="프롬프트 저장에 문제가 생겼어요.";
-    public static final String PROMPT_NULL_ERROR="해당 프롬프트는 저장소에 있지 않아요.";
+    public static final String PROMPT_TEMPLATE_NOT_FOUND="해당 프롬프트는 저장소에 있지 않아요.";
+
 
 
 

--- a/src/main/java/jpabasic/truthaiserver/exception/ErrorMessages.java
+++ b/src/main/java/jpabasic/truthaiserver/exception/ErrorMessages.java
@@ -10,12 +10,19 @@ public class ErrorMessages {
     public static final String LLM_NULL_ERROR="선택된 모델이 없습니다.";
     public static final String ENUM_ERROR="ENUM 값이 제대로 파싱되지 않습니다.";
     public static final String MESSAGE_NULL_ERROR="전달 받은 답변이 없어요.";
+    public static final String ANSWER_RENDER_ERROR="AI 답변 파싱 과정에서 오류가 발생했어요.";
+
 
 
     //prompt 관련
     public static final String PROMPT_GENERATE_ERROR="프롬프트 저장에 문제가 생겼어요.";
     public static final String PROMPT_TEMPLATE_NOT_FOUND="해당 프롬프트는 저장소에 있지 않아요.";
     public static final String PROMPT_NOT_FOUND="해당 질문을 찾을 수 없어요.";
+
+    //souce 관련
+    public static final String SOURCE_URL_EMPTY="출처의 URL이 없어요.";
+    public static final String SAVE_SOURCE_ERROR="Source 저장 과정에서 오류가 발생했어요.";
+
 
 
 

--- a/src/main/java/jpabasic/truthaiserver/repository/AnswerRepository.java
+++ b/src/main/java/jpabasic/truthaiserver/repository/AnswerRepository.java
@@ -1,10 +1,12 @@
 package jpabasic.truthaiserver.repository;
 
 import jpabasic.truthaiserver.domain.Answer;
+import jpabasic.truthaiserver.domain.LLMModel;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
 
 public interface AnswerRepository extends JpaRepository<Answer, Long> {
+    Answer findByPromptIdAndModel(Long promptId, LLMModel model);
     List<Answer> findByPromptId(Long promptId);
 }

--- a/src/main/java/jpabasic/truthaiserver/repository/SourceRepository.java
+++ b/src/main/java/jpabasic/truthaiserver/repository/SourceRepository.java
@@ -1,0 +1,7 @@
+package jpabasic.truthaiserver.repository;
+
+import jpabasic.truthaiserver.domain.Source;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface SourceRepository extends JpaRepository<Source, Long> {
+}

--- a/src/main/java/jpabasic/truthaiserver/service/AnswerService.java
+++ b/src/main/java/jpabasic/truthaiserver/service/AnswerService.java
@@ -10,6 +10,7 @@ import jpabasic.truthaiserver.dto.answer.gemini.GeminiRequestDto;
 import jpabasic.truthaiserver.dto.answer.gemini.GeminiResponseDto;
 import jpabasic.truthaiserver.dto.answer.openai.ChatGptRequest;
 import jpabasic.truthaiserver.dto.answer.openai.ChatGptResponse;
+import jpabasic.truthaiserver.dto.prompt.PromptAnswerDto;
 import jpabasic.truthaiserver.exception.BusinessException;
 import jpabasic.truthaiserver.exception.ErrorMessages;
 import jpabasic.truthaiserver.repository.AnswerRepository;
@@ -24,6 +25,7 @@ import static jpabasic.truthaiserver.domain.LLMModel.CLAUDE;
 import static jpabasic.truthaiserver.domain.LLMModel.GPT;
 import static jpabasic.truthaiserver.domain.LLMModel.GEMINI;
 import static jpabasic.truthaiserver.domain.LLMModel.PERPLEXITY;
+import static jpabasic.truthaiserver.exception.ErrorMessages.PROMPT_NOT_FOUND;
 
 @Service
 @Slf4j
@@ -72,6 +74,17 @@ public class AnswerService {
 
     }
 
+
+    public Answer getAnswer(PromptAnswerDto dto) {
+        Long promptId = dto.promptId();
+        Answer answer = null;
+        try {
+            answer = answerRepository.findByPromptIdAndModel(promptId, GPT);
+        } catch (Exception e) {
+            new BusinessException(ErrorMessages.MESSAGE_NULL_ERROR);
+        }
+        return answer;
+    }
 
 
 

--- a/src/main/java/jpabasic/truthaiserver/service/LlmService.java
+++ b/src/main/java/jpabasic/truthaiserver/service/LlmService.java
@@ -53,6 +53,9 @@ public class LlmService {
         return gptClient(request);
     }
 
+    //LLM 응답을 dto로 반환
+
+
     public String gptClient(ChatGptRequest request){
         //webClient로 OpenAI로 호출
         ChatGptResponse chatGptResponse=openAiWebClient.post()

--- a/src/main/java/jpabasic/truthaiserver/service/LlmService.java
+++ b/src/main/java/jpabasic/truthaiserver/service/LlmService.java
@@ -1,5 +1,6 @@
 package jpabasic.truthaiserver.service;
 
+import jpabasic.truthaiserver.dto.LLMResultDto;
 import jpabasic.truthaiserver.dto.answer.Message;
 import jpabasic.truthaiserver.dto.answer.claude.ClaudeRequest;
 import jpabasic.truthaiserver.dto.answer.claude.ClaudeResponse;
@@ -7,6 +8,7 @@ import jpabasic.truthaiserver.dto.answer.gemini.GeminiRequestDto;
 import jpabasic.truthaiserver.dto.answer.gemini.GeminiResponseDto;
 import jpabasic.truthaiserver.dto.answer.openai.ChatGptRequest;
 import jpabasic.truthaiserver.dto.answer.openai.ChatGptResponse;
+import jpabasic.truthaiserver.dto.prompt.PromptAnswerDto;
 import jpabasic.truthaiserver.repository.AnswerRepository;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -54,7 +56,9 @@ public class LlmService {
     }
 
     //LLM 응답을 dto로 반환
-
+    public PromptAnswerDto seperateAnswers(Long promptId,String response){
+        return new PromptAnswerDto(promptId,response);
+    }
 
     public String gptClient(ChatGptRequest request){
         //webClient로 OpenAI로 호출

--- a/src/main/java/jpabasic/truthaiserver/service/LlmService.java
+++ b/src/main/java/jpabasic/truthaiserver/service/LlmService.java
@@ -32,12 +32,14 @@ public class LlmService {
     private final WebClient openAiWebClient;
     private final WebClient claudeClient;
     private final WebClient geminiClient;
+    private final WebClient perplexityClient;
 
-    public LlmService(WebClient.Builder webClientBuilder,WebClient openAiWebClient,WebClient claudeClient,WebClient geminiClient) {
+    public LlmService(WebClient.Builder webClientBuilder,WebClient openAiWebClient,WebClient claudeClient,WebClient geminiClient,WebClient perplexityClient) {
         this.webClientBuilder = webClientBuilder;
         this.openAiWebClient = openAiWebClient;
         this.claudeClient=claudeClient;
         this.geminiClient=geminiClient;
+        this.perplexityClient=perplexityClient;
 
     }
 
@@ -96,4 +98,15 @@ public class LlmService {
                 .getParts().get(0)
                 .getText();
     }
+
+//    public String createPerplexityAnswer(String question){
+//
+//        PerplexityResponseDto response=perplexityClient.post()
+//                .uri("")
+//                .bodyValue(request)
+//                .retrieve()
+//                .bodyToMono(PerplexityResponseDto.class)
+//                .block();
+//        return response.getChoices(0).getMessage().getContent();
+//    }
 }

--- a/src/main/java/jpabasic/truthaiserver/service/SourcesService.java
+++ b/src/main/java/jpabasic/truthaiserver/service/SourcesService.java
@@ -1,0 +1,102 @@
+package jpabasic.truthaiserver.service;
+
+import jpabasic.truthaiserver.domain.Answer;
+import jpabasic.truthaiserver.domain.Source;
+import jpabasic.truthaiserver.dto.prompt.PromptAnswerDto;
+import jpabasic.truthaiserver.exception.BusinessException;
+import jpabasic.truthaiserver.repository.SourceRepository;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.util.*;
+
+import static jpabasic.truthaiserver.exception.ErrorMessages.SOURCE_URL_EMPTY;
+
+@Service
+@Slf4j
+public class SourcesService {
+
+    private final SourceRepository sourceRepository;
+    private final AnswerService answerService;
+
+    public SourcesService(SourceRepository sourceRepository,AnswerService answerService) {
+        this.sourceRepository = sourceRepository;
+        this.answerService = answerService;
+    }
+
+    //Sources 분리
+    public List<Map<String,String>> separateUrl(PromptAnswerDto dto) {
+        // 예시 입력(실사용 시 dto.sources() 등으로 대체)
+        String sourceText=dto.sources();
+//        String sourceText = "Sources\n" +
+//                " - 한국경제TV, \"롤드컵 치르는 중인 LoL개미, 침착맨 티빙으로 영상 제공\", https://www.hankyung.com/entertainment/article/201910309907q\n" +
+//                " - KBS, \"2년만에 돌아온 '침착맨'...본명은 유준상, 백업 중에 입 닫은 이유는?\", https://entertain.v.daum.net/v/20200818132311568";
+
+        List<Map<String, String>> results = new ArrayList<>();
+
+        // 줄 단위로 자르기 (CR/LF 모두 대응)
+        String[] lines = sourceText.split("\\r?\\n");
+        for (String raw : lines) {
+            String line = raw.trim();
+            if (line.isEmpty()) continue;
+            if (line.equalsIgnoreCase("Sources")) continue; // 헤더 스킵
+            if (line.startsWith("-")) line = line.substring(1).trim(); // 불릿 제거
+
+            int idx = line.indexOf("http"); // URL 시작 지점
+            if (idx == -1) {
+                // URL이 없다면 비즈니스 규칙에 따라 스킵 or 예외
+                return Collections.emptyList();
+                // continue;  // 스킵하고 싶으면 예외 대신 이 줄 사용
+            }
+
+            String title = line.substring(0, idx).trim();
+            String url   = line.substring(idx).trim();
+
+            // URL 뒤에 붙을 수 있는 꼬리문자 정리(선택)
+            url = url.replaceAll("[)\\]\\}>\"',.]+$", "");
+
+            // title 앞/뒤의 잔여 콤마/공백 정리(선택)
+            title = title.replaceAll("^,\\s*|\\s*,\\s*$", "");
+
+            Map<String, String> map = new HashMap<>();
+            map.put("title", title);
+            map.put("url", url);
+            results.add(map);
+
+            // 확인용 로그
+            System.out.println("title = " + title);
+            System.out.println("url   = " + url);
+        }
+
+        // 결과 리스트 사용
+        System.out.println("results = " + results);
+        return results;
+    }
+
+
+
+    //Sources 저장
+    public void saveSources(PromptAnswerDto dto) {
+
+        Answer answer=answerService.getAnswer(dto);
+
+        List<Map<String, String>> result = separateUrl(dto);
+        for (Map<String, String> source : result) {
+            String title = source.get("title");
+            String url = source.get("url");
+
+            System.out.println("title = " + title);
+            System.out.println("url = " + url);
+
+            try {
+                Source newSource = new Source(title, url,answer);
+                sourceRepository.save(newSource);
+            } catch (Exception e) {
+                throw new BusinessException("SAVE_SOURCE_ERROR");
+            }
+        }
+    }
+
+
+
+}

--- a/src/main/java/jpabasic/truthaiserver/service/prompt/OptimizedTemplate.java
+++ b/src/main/java/jpabasic/truthaiserver/service/prompt/OptimizedTemplate.java
@@ -1,5 +1,6 @@
 package jpabasic.truthaiserver.service.prompt;
 
+import jpabasic.truthaiserver.domain.PromptDomain;
 import jpabasic.truthaiserver.dto.answer.Message;
 import jpabasic.truthaiserver.dto.prompt.BasePromptTemplate;
 import org.springframework.stereotype.Component;
@@ -8,22 +9,23 @@ import org.springframework.stereotype.Component;
 public class OptimizedTemplate extends BasePromptTemplate {
     @Override
     //도메인 + 페르소나
-    protected String systemIdentity(String domain,String persona) {
+    protected String systemIdentity(PromptDomain domain,String persona) {
 
         return String.format("You are an expert %s advisor and educator for %s.",domain,persona);
 
     }
 
-    @Override
-    protected String domainGuidelines() {
-        return """
-            # Constraints
-                - Do not reveal internal reasoning. Instead, include a one-sentence rationale labeled "Why".
-                - There must be a specific source with "Why"
-                - If key facts may be time-sensitive, state that you would verify with recent sources before finalizing.
-                - Be clear, specific, and avoid hedging.
-            """;
-    }
+//    @Override
+//    protected String domainGuidelines() {
+//        return """
+//            # Constraints
+//                - Do not reveal internal reasoning. Instead, include a one-sentence rationale labeled "Why".
+//                - There must be a specific source with "Why"
+//                - If key facts may be time-sensitive, state that you would verify with recent sources before finalizing.
+//                - Be clear, specific, and avoid hedging.
+//                - If there is no 100% accurate sources, say "i can't find right sources. sorry", then don't give any sources.
+//            """;
+//    }
 
 
     @Override
@@ -38,13 +40,6 @@ public class OptimizedTemplate extends BasePromptTemplate {
                 
                 ## Question: ```%s```
                 
-                ## Output format (strict):
-                1) Think and prepare your answer in English internally, but only ouptut the final answer in Korean. Do not include English text in the output.
-                2) Why: Provide a concise reason explaining why your answer is correct or reliable, and clearly reference the sources. 
-                3) Sources: List at least 2 different credible source URLs you used, in bullet point format. Eacu URL must be directly relevant to the content. 
-                
-            
-                
                 
                 """.formatted(text);
     }
@@ -56,7 +51,7 @@ public class OptimizedTemplate extends BasePromptTemplate {
 
 
 
-    public String getOptimizedPrompt(String domain,String persona,Message message) {
+    public String getOptimizedPrompt(PromptDomain domain, String persona, Message message) {
         StringBuilder sb=new StringBuilder();
         sb.append(systemIdentity(domain,persona)).append("\n\n")
                 .append(domainGuidelines()).append("\n\n")

--- a/src/main/java/jpabasic/truthaiserver/service/prompt/OptimizedTemplate.java
+++ b/src/main/java/jpabasic/truthaiserver/service/prompt/OptimizedTemplate.java
@@ -1,0 +1,66 @@
+package jpabasic.truthaiserver.service.prompt;
+
+import jpabasic.truthaiserver.dto.answer.Message;
+import jpabasic.truthaiserver.dto.prompt.BasePromptTemplate;
+import org.springframework.stereotype.Component;
+
+@Component
+public class OptimizedTemplate extends BasePromptTemplate {
+    @Override
+    //도메인 + 페르소나
+    protected String systemIdentity(String domain,String persona) {
+
+        return String.format("You are an expert %s advisor and educator for %s.",domain,persona);
+
+    }
+
+    @Override
+    protected String domainGuidelines() {
+        return """
+            # Constraints
+                - Do not reveal internal reasoning. Instead, include a one-sentence rationale labeled "Why".
+                - There must be a specific source with "Why"
+                - If key facts may be time-sensitive, state that you would verify with recent sources before finalizing.
+                - Be clear, specific, and avoid hedging.
+            """;
+    }
+
+
+    @Override
+    //유저가 하는 질문
+    protected String userContent(Message message) {
+        String text=message.getContent();
+        return """
+                ## Your task:
+                Answer the following question, delimited by triple backticks.\s
+                Provide a detailed and well-structured answer with at least 3 paragraphs. Include examples, explanations, and comparisons if relevant. 
+                
+                
+                ## Question: ```%s```
+                
+                ## Output format (strict):
+                1) Think and prepare your answer in English internally, but only ouptut the final answer in Korean. Do not include English text in the output.
+                2) Why: Provide a concise reason explaining why your answer is correct or reliable, and clearly reference the sources. 
+                3) Sources: List at least 2 different credible source URLs you used, in bullet point format. Eacu URL must be directly relevant to the content. 
+                
+            
+                
+                
+                """.formatted(text);
+    }
+
+    @Override
+    public String key() {
+        return "optimized";
+    }
+
+
+
+    public String getOptimizedPrompt(String domain,String persona,Message message) {
+        StringBuilder sb=new StringBuilder();
+        sb.append(systemIdentity(domain,persona)).append("\n\n")
+                .append(domainGuidelines()).append("\n\n")
+                .append(userContent(message));
+        return sb.toString();
+    }
+}

--- a/src/main/java/jpabasic/truthaiserver/service/prompt/PromptEngine.java
+++ b/src/main/java/jpabasic/truthaiserver/service/prompt/PromptEngine.java
@@ -1,6 +1,8 @@
 package jpabasic.truthaiserver.service.prompt;
 
 import jpabasic.truthaiserver.common.prompt.PromptRegistry;
+import jpabasic.truthaiserver.domain.Prompt;
+import jpabasic.truthaiserver.domain.PromptDomain;
 import jpabasic.truthaiserver.dto.answer.LlmRequestDto;
 import jpabasic.truthaiserver.dto.answer.Message;
 import jpabasic.truthaiserver.dto.prompt.PromptTemplate;
@@ -31,12 +33,13 @@ public class PromptEngine {
     //persona 있는 경우
     //최적화 프롬프트 -> 응답까지 생성
     public String execute(String templateKey,LlmRequestDto request){
-       return getOptimizedAnswer(templateKey,new Message(request.getQuestion()),request.getPersona(),request.getDomain());
+       return getOptimizedAnswer(templateKey,new Message(request.getQuestion()),request.getPersona(),request.getPromptDomain());
     }
 
     //최적화 프롬프트 반환(String type)
     public String optimizingPrompt(LlmRequestDto request){
-        String domain=request.getDomain();
+        PromptDomain domain=request.getPromptDomain();
+//        PromptDomain promptDomain=PromptDomain.nameOf(domain);
         String persona=request.getPersona();
         Message message=new Message(request.getQuestion());
 
@@ -44,7 +47,7 @@ public class PromptEngine {
     }
 
     //최적화 프롬프트 반환(List<Message>)
-    private List<Message> executeInternal(String templateKey, Message message, @Nullable String persona,@Nullable String domain){
+    private List<Message> executeInternal(String templateKey, Message message, @Nullable String persona,@Nullable PromptDomain domain){
         PromptTemplate template=registry.getByKey(templateKey);
         if(template==null){
             throw new BusinessException(ErrorMessages.PROMPT_TEMPLATE_NOT_FOUND);
@@ -54,7 +57,7 @@ public class PromptEngine {
     }
 
     //최적화 프롬프트 -> 생성형 ai한테 응답까지 받기
-    private String getOptimizedAnswer(String templateKey, Message message, @Nullable String persona,@Nullable String domain){
+    private String getOptimizedAnswer(String templateKey, Message message, @Nullable String persona,@Nullable PromptDomain domain){
         List<Message> result=executeInternal(templateKey,message,persona,domain);
         return llmService.createGptAnswerWithPrompt(result);
     }

--- a/src/main/java/jpabasic/truthaiserver/service/prompt/PromptEngine.java
+++ b/src/main/java/jpabasic/truthaiserver/service/prompt/PromptEngine.java
@@ -1,12 +1,17 @@
 package jpabasic.truthaiserver.service.prompt;
 
 import jpabasic.truthaiserver.common.prompt.PromptRegistry;
+import jpabasic.truthaiserver.dto.answer.LlmRequestDto;
 import jpabasic.truthaiserver.dto.answer.Message;
 import jpabasic.truthaiserver.dto.prompt.PromptTemplate;
+import jpabasic.truthaiserver.exception.BusinessException;
+import jpabasic.truthaiserver.exception.ErrorMessages;
 import jpabasic.truthaiserver.service.LlmService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.parameters.P;
 import org.springframework.stereotype.Service;
 
+import javax.annotation.Nullable;
 import java.util.List;
 
 @Service
@@ -15,13 +20,43 @@ public class PromptEngine {
 
     private final LlmService llmService;
     private final PromptRegistry registry;
+    private final OptimizedTemplate optimizedTemplate;
 
+
+    //persona 없는 경우
     public String execute(String templateKey,String question){
-        Message message=new Message(question);
+        return getOptimizedAnswer(templateKey,new Message(question),null,null);
+    }
 
+    //persona 있는 경우
+    //최적화 프롬프트 -> 응답까지 생성
+    public String execute(String templateKey,LlmRequestDto request){
+       return getOptimizedAnswer(templateKey,new Message(request.getQuestion()),request.getPersona(),request.getDomain());
+    }
+
+    //최적화 프롬프트 반환(String type)
+    public String optimizingPrompt(LlmRequestDto request){
+        String domain=request.getDomain();
+        String persona=request.getPersona();
+        Message message=new Message(request.getQuestion());
+
+        return optimizedTemplate.getOptimizedPrompt(domain,persona,message);
+    }
+
+    //최적화 프롬프트 반환(List<Message>)
+    private List<Message> executeInternal(String templateKey, Message message, @Nullable String persona,@Nullable String domain){
         PromptTemplate template=registry.getByKey(templateKey);
-        List<Message> result=template.render(message); //기능에 맞는 프롬프트 찾아서 실행
+        if(template==null){
+            throw new BusinessException(ErrorMessages.PROMPT_TEMPLATE_NOT_FOUND);
+        }
+        return template.render(message,persona,domain); //기능에 맞는 프롬프트 찾아서 실행
 
+    }
+
+    //최적화 프롬프트 -> 생성형 ai한테 응답까지 받기
+    private String getOptimizedAnswer(String templateKey, Message message, @Nullable String persona,@Nullable String domain){
+        List<Message> result=executeInternal(templateKey,message,persona,domain);
         return llmService.createGptAnswerWithPrompt(result);
     }
+
 }

--- a/src/main/java/jpabasic/truthaiserver/service/prompt/PromptService.java
+++ b/src/main/java/jpabasic/truthaiserver/service/prompt/PromptService.java
@@ -81,10 +81,12 @@ public class PromptService {
     }
 
 
+    @Transactional
     public Long saveOptimizedPrompt(String optimizedPrompt,Long promptId){
         Prompt prompt=promptRepository.findById(promptId)
                 .orElseThrow(()->new BusinessException(PROMPT_NOT_FOUND));
         prompt.optimize(optimizedPrompt);
+        System.out.println("✅promptId"+prompt.getId());
         return prompt.getId();
     }
 
@@ -103,15 +105,19 @@ public class PromptService {
     }
     
     //최적화된 프롬프트 반환
-    public String getOptimizedPrompt(LlmRequestDto dto,User user) {
-        Long promptId=saveOriginalPrompt(dto,user);
+    public String getOptimizedPrompt(LlmRequestDto dto,Long promptId) {
+//        Long promptId=saveOriginalPrompt(dto,user);
         String optimizedPrompt=promptEngine.optimizingPrompt(dto);
         saveOptimizedPrompt(optimizedPrompt,promptId);
         return optimizedPrompt;
     }
 
     //gpt 응답 저장
+    @Transactional
     public void saveAnswer(String content,User user,Long promptId,LLMModel model) {
+
+        log.info("✅User:{}",user);
+
         Prompt prompt=promptRepository.findById(promptId)
                 .orElseThrow(()->new BusinessException(PROMPT_NOT_FOUND));
 

--- a/src/main/java/jpabasic/truthaiserver/service/prompt/PromptService.java
+++ b/src/main/java/jpabasic/truthaiserver/service/prompt/PromptService.java
@@ -5,6 +5,7 @@ import jpabasic.truthaiserver.domain.Answer;
 import jpabasic.truthaiserver.domain.Prompt;
 import jpabasic.truthaiserver.domain.User;
 import jpabasic.truthaiserver.dto.answer.LlmAnswerDto;
+import jpabasic.truthaiserver.dto.answer.LlmRequestDto;
 import jpabasic.truthaiserver.exception.BusinessException;
 import jpabasic.truthaiserver.repository.PromptRepository;
 import jpabasic.truthaiserver.repository.UserRepository;
@@ -26,12 +27,14 @@ public class PromptService {
     private final UserRepository userRepository;
     private final LlmService llmService;
     private final PromptEngine promptEngine;
+    private final OptimizedTemplate optimizedTemplate;
 
-    public PromptService(PromptRepository promptRepository, UserRepository userRepository,LlmService llmService,PromptEngine promptEngine) {
+    public PromptService(PromptRepository promptRepository, UserRepository userRepository, LlmService llmService, PromptEngine promptEngine, OptimizedTemplate optimizedTemplate) {
         this.promptRepository = promptRepository;
         this.userRepository = userRepository;
         this.llmService = llmService;
         this.promptEngine = promptEngine;
+        this.optimizedTemplate = optimizedTemplate;
     }
 
 
@@ -70,10 +73,15 @@ public class PromptService {
         return promptEngine.execute("summarize",prompt);
     }
 
-
-//    public String optimizingPrompt(String myPrompt, Long userId) {
-//
-//    }
+    //최적화 프롬프트 실행(현재는 gpt로만)
+    public String optimizingPrompt(LlmRequestDto dto) {
+        return promptEngine.execute("optimized",dto);
+    }
+    
+    //최적화된 프롬프트 반환
+    public String getOptimizedPrompt(LlmRequestDto dto) {
+        return promptEngine.optimizingPrompt(dto);
+    }
 
     @Transactional
     public User searchUser(Long userId){

--- a/src/main/java/jpabasic/truthaiserver/service/prompt/PromptService.java
+++ b/src/main/java/jpabasic/truthaiserver/service/prompt/PromptService.java
@@ -2,11 +2,13 @@ package jpabasic.truthaiserver.service.prompt;
 
 import jakarta.transaction.Transactional;
 import jpabasic.truthaiserver.domain.Answer;
+import jpabasic.truthaiserver.domain.LLMModel;
 import jpabasic.truthaiserver.domain.Prompt;
 import jpabasic.truthaiserver.domain.User;
 import jpabasic.truthaiserver.dto.answer.LlmAnswerDto;
 import jpabasic.truthaiserver.dto.answer.LlmRequestDto;
 import jpabasic.truthaiserver.exception.BusinessException;
+import jpabasic.truthaiserver.repository.AnswerRepository;
 import jpabasic.truthaiserver.repository.PromptRepository;
 import jpabasic.truthaiserver.repository.UserRepository;
 import jpabasic.truthaiserver.service.LlmService;
@@ -14,9 +16,12 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import jpabasic.truthaiserver.exception.ErrorMessages;
 
+import java.util.ArrayList;
 import java.util.List;
 
+import static jpabasic.truthaiserver.domain.LLMModel.GPT;
 import static jpabasic.truthaiserver.exception.ErrorMessages.PROMPT_GENERATE_ERROR;
+import static jpabasic.truthaiserver.exception.ErrorMessages.PROMPT_NOT_FOUND;
 
 
 @Service
@@ -24,17 +29,14 @@ import static jpabasic.truthaiserver.exception.ErrorMessages.PROMPT_GENERATE_ERR
 public class PromptService {
 
     private final PromptRepository promptRepository;
-    private final UserRepository userRepository;
-    private final LlmService llmService;
     private final PromptEngine promptEngine;
-    private final OptimizedTemplate optimizedTemplate;
+    private final AnswerRepository answerRepository;
 
-    public PromptService(PromptRepository promptRepository, UserRepository userRepository, LlmService llmService, PromptEngine promptEngine, OptimizedTemplate optimizedTemplate) {
+
+    public PromptService(PromptRepository promptRepository, PromptEngine promptEngine,AnswerRepository answerRepository) {
         this.promptRepository = promptRepository;
-        this.userRepository = userRepository;
-        this.llmService = llmService;
         this.promptEngine = promptEngine;
-        this.optimizedTemplate = optimizedTemplate;
+        this.answerRepository = answerRepository;
     }
 
 
@@ -45,8 +47,9 @@ public class PromptService {
     }
 
 
-    @Transactional
-    public void savePrompt(String question, List<LlmAnswerDto> results, User user) {
+
+    //최적화 프롬프트 없이 질문했을 때
+    public void savePromptAnswer(String question, List<LlmAnswerDto> results, User user) {
 
         if(results==null || results.isEmpty()){
             throw new BusinessException(ErrorMessages.MESSAGE_NULL_ERROR);
@@ -68,24 +71,58 @@ public class PromptService {
     }
 
 
+    //최적화 전 프롬프트 저장
+    public Long saveOriginalPrompt(LlmRequestDto request,User user) {
+        String originalPrompt=request.getQuestion();
+
+        Prompt prompt=new Prompt(originalPrompt,new ArrayList<>(),user); //answer는 저장 전
+        Prompt saved=promptRepository.save(prompt);
+        return saved.getId();
+    }
+
+
+    public Long saveOptimizedPrompt(String optimizedPrompt,Long promptId){
+        Prompt prompt=promptRepository.findById(promptId)
+                .orElseThrow(()->new BusinessException(PROMPT_NOT_FOUND));
+        prompt.optimize(optimizedPrompt);
+        return prompt.getId();
+    }
+
+
     //프롬프트 내용 요약
     public String summarizePrompts(String prompt){
         return promptEngine.execute("summarize",prompt);
     }
 
     //최적화 프롬프트 실행(현재는 gpt로만)
-    public String optimizingPrompt(LlmRequestDto dto) {
-        return promptEngine.execute("optimized",dto);
+    public String optimizingPrompt(LlmRequestDto dto,User user,Long promptId) {
+        String answer= promptEngine.execute("optimized",dto);
+        LLMModel model=GPT;
+        saveAnswer(answer,user,promptId,model);
+        return answer;
     }
     
     //최적화된 프롬프트 반환
-    public String getOptimizedPrompt(LlmRequestDto dto) {
-        return promptEngine.optimizingPrompt(dto);
+    public String getOptimizedPrompt(LlmRequestDto dto,User user) {
+        Long promptId=saveOriginalPrompt(dto,user);
+        String optimizedPrompt=promptEngine.optimizingPrompt(dto);
+        saveOptimizedPrompt(optimizedPrompt,promptId);
+        return optimizedPrompt;
     }
 
-    @Transactional
-    public User searchUser(Long userId){
-        return userRepository.findById(userId)
-                .orElseThrow(()-> new BusinessException(ErrorMessages.USER_NULL_ERROR));
+    //gpt 응답 저장
+    public void saveAnswer(String content,User user,Long promptId,LLMModel model) {
+        Prompt prompt=promptRepository.findById(promptId)
+                .orElseThrow(()->new BusinessException(PROMPT_NOT_FOUND));
+
+        //Answer entity 생성
+        Answer answer=new Answer(content,model,prompt,user);
+        answerRepository.save(answer);
+
+        // Prompt entity와 매핑
+        prompt.addAnswer(answer);
+
     }
+
+
 }

--- a/src/main/java/jpabasic/truthaiserver/service/prompt/SummarizeTemplate.java
+++ b/src/main/java/jpabasic/truthaiserver/service/prompt/SummarizeTemplate.java
@@ -20,6 +20,11 @@ public class SummarizeTemplate extends BasePromptTemplate {
     }
 
     @Override
+    protected String systemIdentity(String domain, String persona) {
+        return "";
+    }
+
+    @Override
     protected String domainGuidelines(){
         return """
                  # 제목 만들기 가이드

--- a/src/main/java/jpabasic/truthaiserver/service/prompt/SummarizeTemplate.java
+++ b/src/main/java/jpabasic/truthaiserver/service/prompt/SummarizeTemplate.java
@@ -1,5 +1,6 @@
 package jpabasic.truthaiserver.service.prompt;
 
+import jpabasic.truthaiserver.domain.PromptDomain;
 import jpabasic.truthaiserver.dto.prompt.BasePromptTemplate;
 import jpabasic.truthaiserver.dto.answer.Message;
 import org.springframework.stereotype.Component;
@@ -19,8 +20,10 @@ public class SummarizeTemplate extends BasePromptTemplate {
                 """.formatted(text);
     }
 
+
+
     @Override
-    protected String systemIdentity(String domain, String persona) {
+    protected String systemIdentity(PromptDomain domain, String persona) {
         return "";
     }
 

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -19,6 +19,15 @@ spring:
     hibernate:
       ddl-auto: update
     database-platform: org.hibernate.dialect.MySQL8Dialect
+    properties:
+      hibernate:
+        format_sql: true
+        generate_statistics: true
+
+logging:
+  level:
+    org.hibernate.SQL: debug
+    org.hibernate.type.descriptor.sql.BasicBinder: trace
 
 embedding:
   vec-path: classpath:models/ko-emb.vec  # 또는 file:/절대/경로/ko-emb.vec

--- a/src/main/resources/application-llm.yml
+++ b/src/main/resources/application-llm.yml
@@ -15,3 +15,7 @@ gemini:
     key: ${GEMINI_API_KEY}
     url: https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash:generateContent
 
+perplexity:
+  api:
+    key: ${PERPLEXITY_API_KEY}
+    url: https://api.perplexity.ai/chat/completions

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -19,3 +19,4 @@ spring:
 embedding:
   vec-path: classpath:models/ko-emb.vec  # 또는 file:/절대/경로/ko-emb.vec
   dim: 200
+


### PR DESCRIPTION
### ✅PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### ✅반영 브랜치
feat/#13 -> main

### ✅변경 사항
- domain, persona, question 입력 후 최적화 프롬프트 생성할 수 있도록 했습니다.
<img width="1120" height="456" alt="image" src="https://github.com/user-attachments/assets/99840524-0b53-4c00-a985-70025d2112d4" />
(현재는 영어로 하드코딩 된 프롬프트만 있고, 계속해서 프롬프트는 성능 향상을 위해 수정할 예정입니다.)


- few-shot prompt engineering을 통해 일정한 형식으로 생성형 ai의 응답을 받을 수 있도록 했습니다.
- 출처(sources) 저장은 ai 교차 검증 시에 저장할 수 있도록 할 예정입니다.
- 유저가 직접 프롬프트를 수정해서 응답을 받을 수 있도록 하는 부분은 추가될 예정입니다.

### ✅테스트 결과

