### PR TITLE
Fix/#19 구글 로그인 토큰 처리 관련 수정

### DIFF
--- a/src/main/java/jpabasic/truthaiserver/controller/UserController.java
+++ b/src/main/java/jpabasic/truthaiserver/controller/UserController.java
@@ -1,17 +1,64 @@
+//package jpabasic.truthaiserver.controller;
+//
+//import jakarta.annotation.PostConstruct;
+//import jpabasic.truthaiserver.dto.TokenDto;
+//import jpabasic.truthaiserver.service.AuthService;
+//import jpabasic.truthaiserver.service.LoginService;
+//import lombok.RequiredArgsConstructor;
+//import lombok.extern.slf4j.Slf4j;
+//import org.springframework.beans.factory.annotation.Value;
+//import org.springframework.web.bind.annotation.*;
+//import jakarta.servlet.http.HttpSession;
+//import jpabasic.truthaiserver.dto.GoogleInfoDto;
+//import org.springframework.http.ResponseEntity;
+//import org.springframework.web.bind.annotation.PostMapping;
+//
+//import java.util.Map;
+//
+//@RestController
+//@RequestMapping("/auth")
+//@RequiredArgsConstructor
+//@Slf4j
+//public class UserController {
+//    private final AuthService authService;
+//    private final LoginService loginService;
+//
+//    @PostMapping("/login")
+//    public ResponseEntity<Map<String, String>> login(@RequestBody TokenDto dto, HttpSession session) {
+//        String token = dto.getToken(); // ✅ 인스턴스에서 꺼냄
+//        log.info("받은 토큰: {}", token);
+//        GoogleInfoDto authenticate = authService.authenticate(token);
+//        Map<String, String> tokens = loginService.processUserLogin(authenticate);
+//        session.setAttribute("accessToken", tokens.get("accessToken"));
+//        session.setAttribute("refreshToken", tokens.get("refreshToken"));
+//        log.info("유저 정보: {}", authenticate);
+//        return ResponseEntity.ok(tokens);
+//    }
+//
+//    @PostMapping("/logout")
+//    public ResponseEntity<Void> logout(HttpSession session) {
+//        session.invalidate();
+//        return ResponseEntity.ok().build();
+//    }
+//
+//}
+
 package jpabasic.truthaiserver.controller;
 
-import jakarta.annotation.PostConstruct;
+import io.swagger.v3.oas.annotations.Operation;
+import jakarta.servlet.http.HttpSession;
+import jpabasic.truthaiserver.dto.GoogleInfoDto;
 import jpabasic.truthaiserver.dto.TokenDto;
-import jpabasic.truthaiserver.service.AuthService;
 import jpabasic.truthaiserver.service.LoginService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.web.bind.annotation.*;
-import jakarta.servlet.http.HttpSession;
-import jpabasic.truthaiserver.dto.GoogleInfoDto;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import jpabasic.truthaiserver.service.AuthService;
+
 
 import java.util.Map;
 
@@ -20,25 +67,33 @@ import java.util.Map;
 @RequiredArgsConstructor
 @Slf4j
 public class UserController {
+
     private final AuthService authService;
     private final LoginService loginService;
 
     @PostMapping("/login")
+    @Operation(summary = "구글 로그인", description = "구글 로그인 인가 코드를 받아 사용자 인증을 합니다.")
     public ResponseEntity<Map<String, String>> login(@RequestBody TokenDto dto, HttpSession session) {
-        String token = dto.getToken(); // ✅ 인스턴스에서 꺼냄
-        log.info("받은 토큰: {}", token);
-        GoogleInfoDto authenticate = authService.authenticate(token);
+        String authorizationCode = dto.getToken(); // 클라이언트에서 전달받은 인가 코드
+        String redirectUri = dto.getRedirectUri(); // 프론트가 사용한 리다이렉트 URI
+        log.info("받은 인가 코드: {}", authorizationCode);
+
+        // authorization code + redirect uri로 사용자 인증
+        GoogleInfoDto authenticate = authService.authenticate(authorizationCode, redirectUri);
         Map<String, String> tokens = loginService.processUserLogin(authenticate);
+
+        // 세션 보관(선택): 프론트가 JWT를 관리한다면 세션 사용은 불필요
         session.setAttribute("accessToken", tokens.get("accessToken"));
         session.setAttribute("refreshToken", tokens.get("refreshToken"));
-        log.info("유저 정보: {}", authenticate);
-        return ResponseEntity.ok(tokens);
+        log.info("구글 사용자 정보: {}", authenticate);
+
+        return ResponseEntity.ok(tokens);  // 액세스 토큰과 리프레시 토큰 반환
     }
 
     @PostMapping("/logout")
+    @Operation(summary = "로그아웃", description = "사용자 로그아웃")
     public ResponseEntity<Void> logout(HttpSession session) {
         session.invalidate();
         return ResponseEntity.ok().build();
     }
-
 }

--- a/src/main/java/jpabasic/truthaiserver/dto/TokenDto.java
+++ b/src/main/java/jpabasic/truthaiserver/dto/TokenDto.java
@@ -3,9 +3,14 @@ package jpabasic.truthaiserver.dto;
 import lombok.Getter;
 import lombok.Setter;
 
-// 내부 클래스든 별도 클래스든 상관 없음
+/**
+ * 프론트에서 전달하는 구글 OAuth2 로그인 요청 바디
+ * - token: authorization code (구글 인가 코드)
+ * - redirectUri: 구글 콘솔에 등록된 리다이렉트 URI (code 교환 시 필요)
+ */
 @Getter
 @Setter
 public class TokenDto {
-    private String token;
+    private String token;       // authorization code
+    private String redirectUri; // 구글 리다이렉트 URI
 }

--- a/src/main/java/jpabasic/truthaiserver/service/LoginService.java
+++ b/src/main/java/jpabasic/truthaiserver/service/LoginService.java
@@ -1,7 +1,48 @@
+//package jpabasic.truthaiserver.service;
+//
+//import jpabasic.truthaiserver.domain.User;
+//import jpabasic.truthaiserver.dto.GoogleInfoDto;
+//import lombok.RequiredArgsConstructor;
+//import lombok.extern.slf4j.Slf4j;
+//import org.springframework.stereotype.Service;
+//
+//import java.util.HashMap;
+//import java.util.Map;
+//
+//@Slf4j
+//@RequiredArgsConstructor
+//@Service
+//public class LoginService {
+//    private final UserFindService userFindService;
+//    private final UserRegisterService userRegisterService;
+//    private final JwtService jwtService;
+//
+//    public Map<String, String> processUserLogin(GoogleInfoDto googleInfoDto){
+//        User user = getOrCreateUser(googleInfoDto);
+//        Map<String, String> stringStringMap = generateAuthTokens(user);
+//        log.info("accessToken, RefreshToken : {} ", stringStringMap);
+//        return stringStringMap;
+//    }
+//
+//    private User getOrCreateUser(GoogleInfoDto googleInfoDto){
+//        return userFindService.findUserByEmail(googleInfoDto.getEmail())
+//                .orElseGet(() -> userRegisterService.registerUser(googleInfoDto.toUserRegisterDto()));
+//    }
+//
+//    private Map<String, String> generateAuthTokens(User user){
+//        Map<String, String> tokens = new HashMap<>();
+//        tokens.put("accessToken", jwtService.generateAccessToken(user));
+//        tokens.put("refreshToken", jwtService.generateRefreshToken(user));
+//        return tokens;
+//    }
+//}
 package jpabasic.truthaiserver.service;
 
 import jpabasic.truthaiserver.domain.User;
 import jpabasic.truthaiserver.dto.GoogleInfoDto;
+import jpabasic.truthaiserver.service.JwtService;
+import jpabasic.truthaiserver.service.UserFindService;
+import jpabasic.truthaiserver.service.UserRegisterService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -13,23 +54,24 @@ import java.util.Map;
 @RequiredArgsConstructor
 @Service
 public class LoginService {
+
     private final UserFindService userFindService;
     private final UserRegisterService userRegisterService;
     private final JwtService jwtService;
 
-    public Map<String, String> processUserLogin(GoogleInfoDto googleInfoDto){
+    public Map<String, String> processUserLogin(GoogleInfoDto googleInfoDto) {
         User user = getOrCreateUser(googleInfoDto);
         Map<String, String> stringStringMap = generateAuthTokens(user);
-        log.info("accessToken, RefreshToken : {} ", stringStringMap);
+        log.info("발급된 토큰 : {} ", stringStringMap);
         return stringStringMap;
     }
 
-    private User getOrCreateUser(GoogleInfoDto googleInfoDto){
+    private User getOrCreateUser(GoogleInfoDto googleInfoDto) {
         return userFindService.findUserByEmail(googleInfoDto.getEmail())
                 .orElseGet(() -> userRegisterService.registerUser(googleInfoDto.toUserRegisterDto()));
     }
 
-    private Map<String, String> generateAuthTokens(User user){
+    private Map<String, String> generateAuthTokens(User user) {
         Map<String, String> tokens = new HashMap<>();
         tokens.put("accessToken", jwtService.generateAccessToken(user));
         tokens.put("refreshToken", jwtService.generateRefreshToken(user));

--- a/src/main/resources/static/google-test.html
+++ b/src/main/resources/static/google-test.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Google OAuth2 테스트</title>
+  <title>Google OAuth2 테스트페이지</title>
   <style>
     body { font-family: -apple-system, BlinkMacSystemFont, Segoe UI, Roboto, sans-serif; margin: 24px; }
     label { display:block; margin: 8px 0 4px; font-weight: 600; }

--- a/src/main/resources/static/google-test.html
+++ b/src/main/resources/static/google-test.html
@@ -1,0 +1,102 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Google OAuth2 테스트</title>
+  <style>
+    body { font-family: -apple-system, BlinkMacSystemFont, Segoe UI, Roboto, sans-serif; margin: 24px; }
+    label { display:block; margin: 8px 0 4px; font-weight: 600; }
+    input { width: 100%; max-width: 640px; padding: 8px; margin-bottom: 8px; }
+    button { padding: 8px 12px; margin-right: 8px; cursor: pointer; }
+    .row { margin: 12px 0; }
+    pre { background:#111; color:#0f0; padding:12px; white-space:pre-wrap; max-width: 100%; overflow:auto; }
+    .hint { color:#666; font-size: 13px; }
+  </style>
+</head>
+<body>
+  <h2>Google OAuth2 테스트 페이지</h2>
+  <div class="hint">
+    - 서버에 설정된 client-id/secret과 <b>동일한 Client ID</b>를 입력해야 합니다.<br/>
+    - Redirect URI는 <b>구글 콘솔에 등록된 URI</b>와 정확히 일치해야 합니다. (예: http://localhost:8080/google-test.html)
+  </div>
+
+  <div class="row">
+    <label for="clientId">Google Client ID</label>
+    <input id="clientId" placeholder="예) 1234567890-xxxx.apps.googleusercontent.com" />
+  </div>
+  <div class="row">
+    <label for="redirectUri">Redirect URI</label>
+    <input id="redirectUri" value="http://localhost:8080/google-test.html" />
+  </div>
+  <div class="row">
+    <button id="goAuth">구글 동의창 이동</button>
+    <button id="clear">로그 지우기</button>
+  </div>
+
+  <h3>로그</h3>
+  <pre id="log"></pre>
+
+  <script>
+    const logEl = document.getElementById('log');
+    const log = (msg) => { logEl.textContent += msg + "\n"; };
+    const clearLog = () => { logEl.textContent = ""; };
+
+    document.getElementById('clear').addEventListener('click', clearLog);
+
+    // 구글 동의창 이동
+    document.getElementById('goAuth').addEventListener('click', () => {
+      const clientId = document.getElementById('clientId').value.trim();
+      const redirectUri = document.getElementById('redirectUri').value.trim();
+      if (!clientId || !redirectUri) {
+        log('Client ID와 Redirect URI를 입력하세요.');
+        return;
+      }
+      const authUrl = new URL('https://accounts.google.com/o/oauth2/v2/auth');
+      authUrl.searchParams.set('client_id', clientId);
+      authUrl.searchParams.set('redirect_uri', redirectUri);
+      authUrl.searchParams.set('response_type', 'code');
+      authUrl.searchParams.set('scope', 'openid email profile');
+      authUrl.searchParams.set('access_type', 'offline');
+      authUrl.searchParams.set('prompt', 'consent');
+
+      log('구글 동의창으로 이동합니다...');
+      window.location.href = authUrl.toString();
+    });
+
+    // 리다이렉트되어 돌아온 경우 code 처리
+    (function handleRedirect() {
+      const params = new URLSearchParams(window.location.search);
+      const code = params.get('code');
+      const err = params.get('error');
+      const redirectUri = document.getElementById('redirectUri').value.trim();
+
+      if (err) {
+        log('Google Error: ' + err);
+        return;
+      }
+      if (!code) {
+        log('code 파라미터가 없으면 [구글 동의창 이동]으로 테스트를 시작하세요.');
+        return;
+      }
+
+      log('받은 authorization code: ' + code);
+      fetch('/auth/login', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ token: code, redirectUri })
+      })
+      .then(async (res) => {
+        const text = await res.text();
+        let body = text;
+        try { body = JSON.parse(text); } catch (_) {}
+        log('응답 상태: ' + res.status);
+        log('응답 바디: ' + (typeof body === 'string' ? body : JSON.stringify(body, null, 2)));
+      })
+      .catch(e => {
+        log('요청 실패: ' + (e && e.message ? e.message : e));
+      });
+    })();
+  </script>
+</body>
+</html> 


### PR DESCRIPTION
### ✅PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### ✅반영 브랜치
ex) fix/#19 -> main

### ✅변경 사항
- 클라이언트에서 전달받은 구글 인가 코드를 통해 구글 로그인 인증 처리하는 부분 수정
- 기존에는 구글 로그인 ID 토큰을 받았으나, 현재는 구글 인가 코드를 받는 방식으로 변경
- 구글 인가 코드를 이용해 백엔드에서 구글 사용자 정보를 가져오는 방식으로 수정

### ✅테스트 결과
<img width="520" height="84" alt="스크린샷 2025-08-19 오후 10 40 03" src="https://github.com/user-attachments/assets/6e72f59c-7249-4e17-bf2c-2aef6cac24c5" />

