### PR TITLE
[fix] llm으로부터 응답 받는 api 오류 수정

### DIFF
--- a/src/main/java/jpabasic/truthaiserver/config/AiConfig.java
+++ b/src/main/java/jpabasic/truthaiserver/config/AiConfig.java
@@ -4,7 +4,10 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpHeaders;
 import org.springframework.web.reactive.function.client.WebClient;
+
+
 
 @Configuration
 @Slf4j
@@ -63,7 +66,7 @@ public class AiConfig {
     @Bean
     public WebClient geminiClient(){
         return webClientBuilder
-                .baseUrl(geminiApiUrl)
+                .baseUrl("https://generativelanguage.googleapis.com/v1beta")
                 .build();
     }
 
@@ -71,7 +74,7 @@ public class AiConfig {
     public WebClient perplexityClient(){
         return webClientBuilder
                 .baseUrl(perplexityApiUrl)
-                .defaultHeader("Authorization","Bearer "+perplexityApiKey)
+//                .defaultHeader("Authorization","Bearer "+perplexityApiKey)
                 .build();
     }
 

--- a/src/main/java/jpabasic/truthaiserver/controller/AnswerController.java
+++ b/src/main/java/jpabasic/truthaiserver/controller/AnswerController.java
@@ -5,6 +5,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpSession;
 import jpabasic.truthaiserver.domain.LLMModel;
 import jpabasic.truthaiserver.domain.User;
+import jpabasic.truthaiserver.dto.LlmNoPromptRequestDto;
 import jpabasic.truthaiserver.dto.answer.LlmAnswerDto;
 import jpabasic.truthaiserver.dto.answer.LlmRequestDto;
 import jpabasic.truthaiserver.exception.BusinessException;
@@ -13,45 +14,42 @@ import jpabasic.truthaiserver.repository.UserRepository;
 import jpabasic.truthaiserver.service.AnswerService;
 import jpabasic.truthaiserver.service.JwtService;
 import jpabasic.truthaiserver.service.prompt.PromptService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
 
 @RestController
-@Tag(name="AI 답변 관련 api")
+@Tag(name = "AI 답변 관련 api")
 @RequestMapping("/llm-answer")
 public class AnswerController {
 
     private final AnswerService answerService;
-    private final JwtService jwtService;
-    private final UserRepository userRepository;
     private final PromptService promptService;
 
-    public AnswerController(AnswerService answerService,JwtService jwtService,UserRepository userRepository,PromptService promptService) {
+    public AnswerController(AnswerService answerService, PromptService promptService) {
         this.answerService = answerService;
-        this.jwtService = jwtService;
-        this.userRepository = userRepository;
         this.promptService = promptService;
     }
 
 
     @PostMapping("/models")
-    @Operation(summary="AI 교차검증 > 프롬프트 최적화 없이 유저가 직접 작성한 질문으로 물어볼 때",description = "models 필드는 선택한 모델들(gpt/claude/gemini) 을 리스트로 주세요. ")
-    public List<LlmAnswerDto> getLlmAnswer(@RequestBody LlmRequestDto llmRequestDto){
-//        String token=(String) session.getAttribute("accessToken");
-//        Long userId=jwtService.getUserIdByParseToken(token);
-//        User user=userRepository.findById(userId)
-//                        .orElseThrow(()->new BusinessException(ErrorMessages.USER_NULL_ERROR));
-//        System.out.println("✅ userId:");
+    @Operation(summary = "AI 교차검증 > 프롬프트 최적화 없이 유저가 직접 작성한 질문으로 물어볼 때", description = "models 필드는 선택한 모델들(gpt/claude/gemini) 을 리스트로 주세요. ")
+    public ResponseEntity<List<LlmAnswerDto>> getLlmAnswer(@RequestBody LlmNoPromptRequestDto request, @AuthenticationPrincipal User user) {
 
-        List<LLMModel> modelEnums= llmRequestDto.toModelEnums();
-        String question=llmRequestDto.getQuestion();
+        List<LLMModel> modelEnums = request.toModelEnums();
+        String question = request.question();
 
-        List<LlmAnswerDto> result=answerService.getLlmAnswers(modelEnums,question); //LLM 답변 받기
-//        promptService.savePrompt(question,result,user); //프롬프트 저장 ❓
+        //저장 되는 제목 설정 (질문 내용 요약)
+        String summary = promptService.summarizePrompts(question);
 
-        return result;
+        List<LlmAnswerDto> result = answerService.getLlmAnswers(modelEnums, question); //LLM 답변 받기
+        promptService.savePromptAnswer(question, result, user, summary); // 질문 & 답변 저장
+
+        return ResponseEntity.ok(result);
+
     }
 
 

--- a/src/main/java/jpabasic/truthaiserver/controller/LlmTestController.java
+++ b/src/main/java/jpabasic/truthaiserver/controller/LlmTestController.java
@@ -94,7 +94,7 @@ public class LlmTestController {
                 .bodyToMono(GeminiResponseDto.class)
                 .block();
         return response
-                .getCandidates()
+                .getCandidates().get(0)
                 .getContent()
                 .getParts().get(0)
                 .getText();

--- a/src/main/java/jpabasic/truthaiserver/controller/PromptController.java
+++ b/src/main/java/jpabasic/truthaiserver/controller/PromptController.java
@@ -8,6 +8,7 @@ import jpabasic.truthaiserver.dto.answer.LlmAnswerDto;
 import jpabasic.truthaiserver.dto.answer.LlmRequestDto;
 import jpabasic.truthaiserver.dto.answer.Message;
 import jpabasic.truthaiserver.dto.prompt.LLMResponseDto;
+import jpabasic.truthaiserver.dto.prompt.OptPromptRequestDto;
 import jpabasic.truthaiserver.dto.prompt.PromptAnswerDto;
 import jpabasic.truthaiserver.dto.prompt.PromptResultDto;
 import jpabasic.truthaiserver.service.LlmService;
@@ -38,8 +39,8 @@ public class PromptController {
     }
 
     @PostMapping("/create-best")
-    @Operation(summary="최적화 프롬프트 생성")
-    public ResponseEntity<Map<String,Object>> savePrompt(@RequestBody LlmRequestDto dto,@AuthenticationPrincipal(expression = "user") User user){
+    @Operation(summary="최적화 프롬프트 생성",description = "templateKey 값은 optimzied로 주세요.")
+    public ResponseEntity<Map<String,Object>> savePrompt(@RequestBody OptPromptRequestDto dto, @AuthenticationPrincipal User user){
         Long promptId=promptService.saveOriginalPrompt(dto,user);
         List<Message> optimizedPrompt=promptService.getOptimizedPrompt(dto,promptId);
 

--- a/src/main/java/jpabasic/truthaiserver/domain/Prompt.java
+++ b/src/main/java/jpabasic/truthaiserver/domain/Prompt.java
@@ -36,6 +36,13 @@ public class Prompt extends BaseEntity{
     @OneToMany(mappedBy = "prompt", cascade = CascadeType.ALL)
     private List<Answer> answers = new ArrayList<>();
 
+    public Prompt(String originalPrompt,List<Answer> answers,User user,String summary) {
+        this.originalPrompt = originalPrompt;
+        this.answers = answers;
+        this.user = user;
+        this.summary = summary;
+    }
+
     public Prompt(String originalPrompt,List<Answer> answers,User user) {
         this.originalPrompt = originalPrompt;
         this.answers = answers;

--- a/src/main/java/jpabasic/truthaiserver/dto/LlmNoPromptRequestDto.java
+++ b/src/main/java/jpabasic/truthaiserver/dto/LlmNoPromptRequestDto.java
@@ -1,0 +1,23 @@
+package jpabasic.truthaiserver.dto;
+
+import jpabasic.truthaiserver.domain.LLMModel;
+import jpabasic.truthaiserver.exception.BusinessException;
+import jpabasic.truthaiserver.exception.ErrorMessages;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+public record LlmNoPromptRequestDto (List<String> models,String question){
+
+    public List<LLMModel> toModelEnums(){
+        return models.stream()
+                .map(model->{
+                    try{
+                        return LLMModel.valueOf(model.toUpperCase());
+                    }catch(IllegalArgumentException e){
+                        throw new BusinessException(ErrorMessages.ENUM_ERROR);
+                    }
+                })
+                .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/jpabasic/truthaiserver/dto/answer/LlmRequestDto.java
+++ b/src/main/java/jpabasic/truthaiserver/dto/answer/LlmRequestDto.java
@@ -1,5 +1,6 @@
 package jpabasic.truthaiserver.dto.answer;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jpabasic.truthaiserver.domain.LLMModel;
@@ -20,6 +21,7 @@ public class LlmRequestDto {
 
     @Schema(description="model 선택. gpt, claude, gemini 중 선택한 것 들을 리스트로 주세요.")
     @NotBlank(message="모델을 선택해주세요.")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     private List<String> models;
 
     @NotBlank(message="프롬프트를 작성해주세요.")

--- a/src/main/java/jpabasic/truthaiserver/dto/answer/LlmRequestDto.java
+++ b/src/main/java/jpabasic/truthaiserver/dto/answer/LlmRequestDto.java
@@ -33,17 +33,7 @@ public class LlmRequestDto {
 
     private String templateKey;
 
-    public List<LLMModel> toModelEnums(){
-        return models.stream()
-                .map(model->{
-                    try{
-                        return LLMModel.valueOf(model.toUpperCase());
-                    }catch(IllegalArgumentException e){
-                        throw new BusinessException(ErrorMessages.ENUM_ERROR);
-                    }
-                })
-                .collect(Collectors.toList());
-    }
+
 
 
 }

--- a/src/main/java/jpabasic/truthaiserver/dto/answer/gemini/GeminiRequestDto.java
+++ b/src/main/java/jpabasic/truthaiserver/dto/answer/gemini/GeminiRequestDto.java
@@ -1,5 +1,6 @@
 package jpabasic.truthaiserver.dto.answer.gemini;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -12,9 +13,14 @@ import java.util.List;
 @AllArgsConstructor
 public class GeminiRequestDto {
 
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     private SystemInstruction systemInstruction; //시스템 프롬프트
+
     private List<Contents> contents; //대화 기록
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     private GenerationConfig generationConfig;
+
 
     public static GeminiRequestDto fromText(String systemPrompt,String text) {
         return new GeminiRequestDto(
@@ -23,6 +29,17 @@ public class GeminiRequestDto {
                 new GenerationConfig(1024,0.0,null)
         );
     }
+
+    public static GeminiRequestDto send(String text) {
+
+        return new GeminiRequestDto(
+                null,
+                List.of(new Contents(List.of(new Part(text)))),
+                new GenerationConfig(1024, 0.0, null)
+        );
+    }
+
+
 
     @Data
     @NoArgsConstructor

--- a/src/main/java/jpabasic/truthaiserver/dto/answer/gemini/GeminiResponseDto.java
+++ b/src/main/java/jpabasic/truthaiserver/dto/answer/gemini/GeminiResponseDto.java
@@ -1,26 +1,38 @@
 package jpabasic.truthaiserver.dto.answer.gemini;
 
+import lombok.AllArgsConstructor;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
 import java.util.List;
 
 @Data
+@NoArgsConstructor
+@AllArgsConstructor
 public class GeminiResponseDto {
-
-    private Candidate candidates;
+    private List<Candidate> candidates;
 
     @Data
+    @NoArgsConstructor
+    @AllArgsConstructor
     public static class Candidate {
         private Content content;
+        // 필요 시: finishReason, safetyRatings 등 추가
     }
 
     @Data
+    @NoArgsConstructor
+    @AllArgsConstructor
     public static class Content {
-        private List<Part> parts;
+        private String role;            // "model"
+        private List<Part> parts;       // [{text: "..."}]
     }
 
     @Data
-    public static class Part{
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class Part {
         private String text;
     }
 }
+

--- a/src/main/java/jpabasic/truthaiserver/dto/prompt/OptPromptRequestDto.java
+++ b/src/main/java/jpabasic/truthaiserver/dto/prompt/OptPromptRequestDto.java
@@ -1,0 +1,27 @@
+package jpabasic.truthaiserver.dto.prompt;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jpabasic.truthaiserver.domain.PromptDomain;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Data
+public class OptPromptRequestDto {
+
+
+    @NotBlank(message="프롬프트를 작성해주세요.")
+    private String question;
+
+    @Schema(description="페르소나:최적화 생성 시에만 입력 필수",required=false)
+    private String persona;
+
+    @Schema(description="도메인 : 유저가 물어보려는 내용의 분야",required=false)
+    private PromptDomain promptDomain;
+
+    private String templateKey;
+}

--- a/src/main/java/jpabasic/truthaiserver/exception/ErrorMessages.java
+++ b/src/main/java/jpabasic/truthaiserver/exception/ErrorMessages.java
@@ -25,7 +25,7 @@ public class ErrorMessages {
 
 
     //prompt 관련
-    public static final String PROMPT_GENERATE_ERROR="프롬프트 저장에 문제가 생겼어요.";
+    public static final String PROMPT_SAVE_ERROR="프롬프트 저장에 문제가 생겼어요.";
     public static final String PROMPT_TEMPLATE_NOT_FOUND="해당 프롬프트는 저장소에 있지 않아요.";
     public static final String PROMPT_NOT_FOUND="해당 질문을 찾을 수 없어요.";
 

--- a/src/main/java/jpabasic/truthaiserver/service/AnswerService.java
+++ b/src/main/java/jpabasic/truthaiserver/service/AnswerService.java
@@ -44,21 +44,21 @@ public class AnswerService {
 
         return models.stream()
                 .map(model -> switch (model) {
-                    case GPT -> saveLlmAnswer(GPT, llmService.createGptAnswer(question));
-                    case CLAUDE -> saveLlmAnswer(CLAUDE, llmService.createClaudeAnswer(question));
+                    case GPT -> toDto(GPT, llmService.createGptAnswer(question));
+                    case CLAUDE -> toDto(CLAUDE, llmService.createClaudeAnswer(question));
                     //            case PERPLEXITY -> new LlmAnswerDto(PERPLEXITY, createAnswer(PERPLEXITY));
-                    case GEMINI -> saveLlmAnswer(GEMINI, llmService.createGeminiAnswer(question));
+                    case GEMINI -> toDto(GEMINI, llmService.createGeminiAnswer(question));
                     default -> throw new BusinessException(ErrorMessages.LLM_MODEL_ERROR);
                 })
                 .toList();
     }
 
 
-    public LlmAnswerDto saveLlmAnswer(LLMModel model,String answer){
+    public LlmAnswerDto toDto(LLMModel model,String answer){
 
         LlmAnswerDto answerDto = new LlmAnswerDto(model,answer);
-        Answer answerEntity=answerDto.toEntity();
-        answerRepository.save(answerEntity);
+//        Answer answerEntity=answerDto.toEntity();
+//        answerRepository.save(answerEntity);
         return answerDto;
 
     }

--- a/src/main/java/jpabasic/truthaiserver/service/prompt/PromptEngine.java
+++ b/src/main/java/jpabasic/truthaiserver/service/prompt/PromptEngine.java
@@ -9,10 +9,7 @@ import jpabasic.truthaiserver.dto.answer.LlmRequestDto;
 import jpabasic.truthaiserver.dto.answer.Message;
 import jpabasic.truthaiserver.dto.answer.claude.ClaudeRequestDto;
 import jpabasic.truthaiserver.dto.answer.gemini.GeminiRequestDto;
-import jpabasic.truthaiserver.dto.prompt.BasePromptTemplate;
-import jpabasic.truthaiserver.dto.prompt.ClaudeAdapter;
-import jpabasic.truthaiserver.dto.prompt.GeminiAdapter;
-import jpabasic.truthaiserver.dto.prompt.LLMResponseDto;
+import jpabasic.truthaiserver.dto.prompt.*;
 import jpabasic.truthaiserver.exception.BusinessException;
 import jpabasic.truthaiserver.exception.ErrorMessages;
 import jpabasic.truthaiserver.service.LlmService;
@@ -136,7 +133,7 @@ public class PromptEngine {
 
 
     //optimized prompt 반환
-    List<Message> getOptimizedPrompt(String templateKey, LlmRequestDto request){
+    List<Message> getOptimizedPrompt(String templateKey, OptPromptRequestDto request){
         Message message=new Message(request.getQuestion());
         String persona=request.getPersona();
         PromptDomain domain=request.getPromptDomain();

--- a/src/main/java/jpabasic/truthaiserver/service/prompt/PromptService.java
+++ b/src/main/java/jpabasic/truthaiserver/service/prompt/PromptService.java
@@ -8,6 +8,7 @@ import jpabasic.truthaiserver.dto.answer.LlmAnswerDto;
 import jpabasic.truthaiserver.dto.answer.LlmRequestDto;
 import jpabasic.truthaiserver.dto.answer.Message;
 import jpabasic.truthaiserver.dto.prompt.LLMResponseDto;
+import jpabasic.truthaiserver.dto.prompt.OptPromptRequestDto;
 import jpabasic.truthaiserver.dto.prompt.PromptAnswerDto;
 import jpabasic.truthaiserver.dto.prompt.PromptResultDto;
 import jpabasic.truthaiserver.dto.sources.SourcesDto;
@@ -78,7 +79,7 @@ public class PromptService {
 
 
     //최적화 전 프롬프트 저장
-    public Long saveOriginalPrompt(LlmRequestDto request,User user) {
+    public Long saveOriginalPrompt(OptPromptRequestDto request, User user) {
         String originalPrompt=request.getQuestion();
 
         Prompt prompt=new Prompt(originalPrompt,new ArrayList<>(),user); //answer는 저장 전
@@ -137,22 +138,10 @@ public class PromptService {
                 return List.of((Map<LLMModel, LLMResponseDto>) answer);
     }
 
-    //최적화 프롬프트 실행(현재는 gpt로만) //⭐병렬 처리 위한 함수
-    public void optimizingPrompt(LlmRequestDto dto,User user,Long promptId) {
-        //최적화된 프롬프트 반환
-        List<Message> answer= promptEngine.getOptimizedPrompt("optimized",dto);
-
-        //모델 리스트 String -> ENUM
-        List<String> models=dto.getModels();
-        List<LLMModel> llmModels=models.stream()
-                        .map(LLMModel::fromString)
-                                .toList();
-
-    }
 
 
     //최적화된 프롬프트 반환
-    public List<Message> getOptimizedPrompt(LlmRequestDto dto,Long promptId) {
+    public List<Message> getOptimizedPrompt(OptPromptRequestDto dto,Long promptId) {
 //        Long promptId=saveOriginalPrompt(dto,user);
         String templateKey=dto.getTemplateKey();
 

--- a/src/main/java/jpabasic/truthaiserver/service/prompt/PromptService.java
+++ b/src/main/java/jpabasic/truthaiserver/service/prompt/PromptService.java
@@ -55,7 +55,7 @@ public class PromptService {
 
 
     //최적화 프롬프트 없이 질문했을 때
-    public void savePromptAnswer(String question, List<LlmAnswerDto> results, User user) {
+    public void savePromptAnswer(String question, List<LlmAnswerDto> results, User user,String summary) {
 
         if(results==null || results.isEmpty()){
             throw new BusinessException(ErrorMessages.MESSAGE_NULL_ERROR);
@@ -67,11 +67,11 @@ public class PromptService {
                 .toList();
 
         try {
-            Prompt prompt = new Prompt(question, answers, user);
+            Prompt prompt = new Prompt(question, answers, user,summary);
             promptRepository.save(prompt);
         } catch (BusinessException e) {
             log.error(e.getMessage());
-            throw new BusinessException(PROMPT_GENERATE_ERROR);
+            throw new BusinessException(PROMPT_SAVE_ERROR);
         }
 
     }
@@ -148,10 +148,6 @@ public class PromptService {
                         .map(LLMModel::fromString)
                                 .toList();
 
-
-
-
-////        return answer;
     }
 
 

--- a/src/main/resources/application-llm.yml
+++ b/src/main/resources/application-llm.yml
@@ -13,7 +13,7 @@ claude:
 gemini:
   api:
     key: ${GEMINI_API_KEY}
-    url: https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash:generateContent
+    url: https://generativelanguage.googleapis.com/v1beta
 
 perplexity:
   api:


### PR DESCRIPTION
### ✅PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### ✅반영 브랜치
fix/#24->main

### ✅변경 사항
- 최적화 프롬프트 생성 시, request 필드 model 받지 않기 
- 프롬프트 없이 유저의 질문에 대답할 때, request 값 수정
: model/persona/.. -> string 하나만 받도록 수정
- gemini 401 오류 수정 : api key 전달 방식을 uri param -> header 방식으로 변경(WebClient 방식에서는 param 정상적으로 전달 X)

### ✅테스트 결과

