### PR TITLE
[fix] 답변 저장 시 userid, promptid 저장 안되던 오류 해결

### DIFF
--- a/src/main/java/jpabasic/truthaiserver/domain/Answer.java
+++ b/src/main/java/jpabasic/truthaiserver/domain/Answer.java
@@ -62,4 +62,13 @@ public class Answer extends BaseEntity{
         this.prompt = prompt;
         this.user = user;
     }
+
+    // 양방향 관계 설정을 위한 setter 메서드들
+    public void setPrompt(Prompt prompt) {
+        this.prompt = prompt;
+    }
+
+    public void setUser(User user) {
+        this.user = user;
+    }
 }

--- a/src/main/java/jpabasic/truthaiserver/domain/Prompt.java
+++ b/src/main/java/jpabasic/truthaiserver/domain/Prompt.java
@@ -36,17 +36,38 @@ public class Prompt extends BaseEntity{
     @OneToMany(mappedBy = "prompt", cascade = CascadeType.ALL)
     private List<Answer> answers = new ArrayList<>();
 
+    // answers 리스트 getter (Lombok @Getter와 함께 작동)
+    public List<Answer> getAnswers() {
+        return answers;
+    }
+
     public Prompt(String originalPrompt,List<Answer> answers,User user,String summary) {
         this.originalPrompt = originalPrompt;
         this.answers = answers;
         this.user = user;
         this.summary = summary;
+        
+        // 양방향 관계 설정: 각 Answer의 prompt와 user 설정
+        if (answers != null) {
+            for (Answer answer : answers) {
+                answer.setPrompt(this);
+                answer.setUser(user);
+            }
+        }
     }
 
     public Prompt(String originalPrompt,List<Answer> answers,User user) {
         this.originalPrompt = originalPrompt;
         this.answers = answers;
         this.user = user;
+        
+        // 양방향 관계 설정: 각 Answer의 prompt와 user 설정
+        if (answers != null) {
+            for (Answer answer : answers) {
+                answer.setPrompt(this);
+                answer.setUser(user);
+            }
+        }
     }
 
     public void assignUser(User user) {
@@ -69,6 +90,11 @@ public class Prompt extends BaseEntity{
 
     public void assignFolder(Folder folder) {
         this.folder = folder;
+    }
+
+    // answers 리스트 설정을 위한 메서드 추가
+    public void setAnswers(List<Answer> answers) {
+        this.answers = answers;
     }
 
 }

--- a/src/main/java/jpabasic/truthaiserver/service/prompt/PromptService.java
+++ b/src/main/java/jpabasic/truthaiserver/service/prompt/PromptService.java
@@ -57,13 +57,14 @@ public class PromptService {
             throw new BusinessException(ErrorMessages.MESSAGE_NULL_ERROR);
         }
 
-        //LlmAnswerDto -> Answer
+        //LlmAnswerDto -> Answer (prompt와 user는 Prompt 생성자에서 설정됨)
         List<Answer> answers = results.stream()
                 .map(dto -> dto.toEntity())
                 .toList();
 
         Long promptId;
         try {
+            // Prompt 생성 시 생성자에서 각 Answer의 prompt와 user 관계를 자동 설정
             Prompt prompt = new Prompt(question, answers, user, summary);
             promptId = promptRepository.save(prompt).getId();
         } catch (BusinessException e) {


### PR DESCRIPTION
- 양방향 연관관계
- 생성자 추가

### ✅PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### ✅반영 브랜치
ex) fix/#53 -> main

### ✅변경 사항
답변 저장 시 userid, promptid 저장 안되던 오류 해결했습니다
prompt 생성자에 answer 정보 저장하도록 수정했습니다.

### ✅테스트 결과
ex) 베이스 브랜치에 포함되기 위한 코드는 모두 정상적으로 동작해야 합니다. 결과물에 대한 스크린샷, GIF, 혹은 라이브 데모가 가능하도록 샘플API를 첨부할 수도 있습니다.
