### PR TITLE
[fix] 모든 교차검증 리스트 반환 안되는 오류 해결

### DIFF
--- a/src/main/java/jpabasic/truthaiserver/repository/PromptRepository.java
+++ b/src/main/java/jpabasic/truthaiserver/repository/PromptRepository.java
@@ -24,7 +24,6 @@ public interface PromptRepository extends JpaRepository<Prompt, Long> {
     @Query("SELECT p FROM Prompt p " +
             "JOIN p.answers a " +
             "WHERE p.user.id = :userId " +
-            "AND p.optimizedPrompt IS NOT NULL " +
             "AND a.score IS NOT NULL")
     List<Prompt> findPromptsWithAnswersAndScoreNotNull(@Param("userId") Long userId);
 


### PR DESCRIPTION
### ✅PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### ✅반영 브랜치
ex) fix/#64 -> main

### ✅변경 사항
모든 교차검증 리스트 요청시 반환 안되는 오류 해결하였습니다.
JPQL 수정했습니다

### ✅테스트 결과
ex) 베이스 브랜치에 포함되기 위한 코드는 모두 정상적으로 동작해야 합니다. 결과물에 대한 스크린샷, GIF, 혹은 라이브 데모가 가능하도록 샘플API를 첨부할 수도 있습니다.
